### PR TITLE
[Bug Fix] Expo reload issues

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -13,7 +13,7 @@ SplashScreen.preventAutoHideAsync();
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   const [loaded] = useFonts({
-    SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
+    // SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
   useEffect(() => {


### PR DESCRIPTION
Commented out font import line that was causing the expo reloads to be stuck on splash screen. See https://github.com/itsme-zeix/NUSMaps/issues/13.