### PR TITLE
fix: removed bug that was causing the error: route not opened

### DIFF
--- a/frontend/components/RouteSearchBar.tsx
+++ b/frontend/components/RouteSearchBar.tsx
@@ -70,6 +70,7 @@ export const RouteSearchBar: React.FC<
         }}
         query={queryParams}
         enablePoweredByContainer={false}
+        debounce={300}
         styles={{
           container: styles.googleSearchBar,
         }}


### PR DESCRIPTION
1. https://github.com/FaridSafi/react-native-google-places-autocomplete/issues/910
2. adding debounce in prop values of the autocomplete search bar fixed the issue