### PR TITLE
Fix IOS location retrieval duration for routefinding and refactor some functions/UI Styling (re-centre button, status bar, bus services)

### DIFF
--- a/frontend/app/(tabs)/__tests__/SegmentedControl.test.tsx
+++ b/frontend/app/(tabs)/__tests__/SegmentedControl.test.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import { render, fireEvent, waitFor, cleanup } from "@testing-library/react-native";
+import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NavigationContainer } from "@react-navigation/native";
+import BusStopsScreen from "@/app/(tabs)/index";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// Mock AsyncStorage
+const mockBusStops = [
+  {
+    busStopId: "1",
+    busStopName: "NUSSTOP_COM3",
+    savedBuses: [{ busNumber: "945A", timings: ["2024-07-29T00:30:00Z", "2024-07-29T01:00:00Z"] }],
+    isFavourited: false,
+  },
+  {
+    busStopId: "2",
+    busStopName: "NUSSTOP_PGPR",
+    savedBuses: [
+      { busNumber: "A1", timings: ["2024-07-30T08:25:00.000Z", "2024-07-30T08:35:00.000Z"] },
+      { busNumber: "A2", timings: ["2024-07-30T08:20:00.000Z", "2024-07-30T08:30:00.000Z"] },
+    ],
+    isFavourited: false,
+  },
+];
+
+let asyncStorageData = JSON.stringify(mockBusStops);
+AsyncStorage.getItem = jest.fn((key) => {
+  return Promise.resolve(asyncStorageData);
+});
+AsyncStorage.setItem = jest.fn((key, value) => {
+  asyncStorageData = value;
+  return Promise.resolve();
+});
+
+// Mock Vector Icons
+jest.mock("react-native-vector-icons/Ionicons", () => "Ionicons");
+jest.mock("@expo/vector-icons", () => {
+  return {
+    Ionicons: "Ionicons",
+    MaterialCommunityIcons: "MaterialCommunityIcons",
+  };
+});
+
+// Mock expo-location
+jest.mock("expo-location", () => {
+  return {
+    requestForegroundPermissionsAsync: jest.fn(async () => ({
+      status: "granted",
+    })),
+    getCurrentPositionAsync: jest.fn(async () => ({
+      coords: {
+        latitude: 1.3521,
+        longitude: 103.8198,
+      },
+    })),
+    getLastKnownPositionAsync: jest.fn(async () => ({
+      coords: {
+        latitude: 1.3521,
+        longitude: 103.8198,
+      },
+    })),
+  };
+});
+
+// Mock SegmentedControl
+jest.mock("@react-native-segmented-control/segmented-control", () => {
+  const { View, Text } = require("react-native");
+  return (props: { values: any[]; onChange: (arg0: { nativeEvent: { selectedSegmentIndex: any } }) => any }) => (
+    <View>
+      {props.values.map((value, index) => (
+        <Text key={index} onPress={() => props.onChange({ nativeEvent: { selectedSegmentIndex: index } })} testID={`segmented-control-${value}`}>
+          {value}
+        </Text>
+      ))}
+    </View>
+  );
+});
+// Mock react-query's useQuery
+jest.mock("@tanstack/react-query", () => ({
+  ...jest.requireActual("@tanstack/react-query"),
+  useQuery: jest.fn().mockImplementation(({ queryKey }) => {
+    switch (queryKey[0]) {
+      case "favouriteBusStops":
+        return { data: [], isLoading: false, isError: false, error: null };
+      case "busStopsByLocation":
+        return { data: mockBusStops, isLoading: false, isError: false, error: null };
+      case "nusBusStops":
+        return { data: mockBusStops, isLoading: false, isError: false, error: null };
+    }
+  }),
+}));
+
+// Create a new query client for each test
+const createQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false, // Disable retries to make tests fail fast
+      },
+    },
+    queryCache: new QueryCache({
+      onError: jest.fn(),
+    }),
+  });
+
+describe("BusStopsScreen", () => {
+  let queryClient: QueryClient;
+  queryClient = createQueryClient();
+  queryClient.setDefaultOptions({ queries: { gcTime: 0 } });
+
+  afterEach(() => {
+    queryClient.clear(); // Clear the query client
+    cleanup(); // Ensure cleanup after each test
+    // jest.clearAllMocks(); // Clear all mocks
+  });
+
+  it("should render FavouriteBusStops, NearbyBusStops, and NUSBusStops when the corresponding tab is selected", async () => {
+    const { getByText, queryByText, getByTestId } = render(
+      <NavigationContainer>
+        <QueryClientProvider client={queryClient}>
+          <BusStopsScreen />
+        </QueryClientProvider>
+      </NavigationContainer>
+    );
+
+    // Initial state - Favourites tab
+    await waitFor(() => {
+      expect(getByText("No bus stops have been favourited yet!")).toBeTruthy();
+    });
+
+    // Navigate to Nearby tab
+    fireEvent.press(getByTestId("segmented-control-Nearby"));
+    await waitFor(() => {
+      expect(queryByText("No bus stops have been favourited yet!")).toBeNull();
+      expect(queryByText("COM 3")).toBeTruthy();
+      expect(queryByText("Prince George's Park Foyer")).toBeTruthy();
+    });
+
+    // Navigate to NUS tab
+    fireEvent.press(getByTestId("segmented-control-NUS"));
+    await waitFor(() => {
+      expect(queryByText("No bus stops have been favourited yet!")).toBeNull();
+      expect(queryByText("COM 3")).toBeTruthy();
+      expect(queryByText("Prince George's Park Foyer")).toBeTruthy();
+    });
+
+    // Navigate back to favourites tab
+    fireEvent.press(getByTestId("segmented-control-Favourites"));
+    await waitFor(() => {
+      expect(getByText("No bus stops have been favourited yet!")).toBeTruthy();
+    });
+  });
+});

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -748,7 +748,7 @@ const NUSBusServices = forwardRef((props, ref) => {
                 }}
                 anchor={{ x: 0.5, y: 0.5 }}
               >
-                <FontAwesome name="location-arrow" size={18} color="#27f" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
+                <FontAwesome name="location-arrow" size={25} color="#27f" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
               </Marker>
             ))}
         </MapView>

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -280,10 +280,10 @@ const NUSBusServices = forwardRef((props, ref) => {
     longitudeDelta: 0.05,
   };
   const BUKITTIMAHCAMPUS = {
-    latitude: 1.320833615554101,
-    longitude: 103.81686475132896,
-    latitudeDelta: 0.01,
-    longitudeDelta: 0.01,
+    latitude: 1.3215,
+    longitude: 103.8165,
+    latitudeDelta: 0.007,
+    longitudeDelta: 0.007,
   };
   const MARKERDIRECTIONS: { [key in NUSBusServices]: DirectionMarker[] } = {
     A1: [

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -274,8 +274,8 @@ const NUSBusServices = forwardRef((props, ref) => {
     longitudeDelta: 0.015,
   };
   const NUS_BTC = {
-    latitude: 1.301243123663655,
-    longitude: 103.80083642680974,
+    latitude: 1.3030,
+    longitude: 103.7955,
     latitudeDelta: 0.05,
     longitudeDelta: 0.05,
   };

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -290,7 +290,7 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.29405,
         longitude: 103.76973,
-        angle: "180deg",
+        angle: "150deg",
       },
       {
         latitude: 1.2955070908079434,
@@ -300,7 +300,7 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.2923086387008367,
         longitude: 103.77409145023913,
-        angle: "20deg",
+        angle: "60deg",
       },
       {
         latitude: 1.2915679763491539,
@@ -315,17 +315,17 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.2974016052916018,
         longitude: 103.78052888927002,
-        angle: "230deg",
+        angle: "215deg",
       },
       {
         latitude: 1.2988500475970672,
         longitude: 103.77579967302323,
-        angle: "220deg",
+        angle: "230deg",
       },
       {
         latitude: 1.2963940606392585,
         longitude: 103.7722840249133,
-        angle: "180deg",
+        angle: "200deg",
       },
     ],
     A2: [
@@ -357,7 +357,7 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.2974154593493992,
         longitude: 103.7802721054462,
-        angle: "60deg",
+        angle: "30deg",
       },
       {
         latitude: 1.29493,
@@ -367,12 +367,12 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.29172907463164,
         longitude: 103.78270417195186,
-        angle: "180deg",
+        angle: "200deg",
       },
       {
         latitude: 1.29297,
         longitude: 103.77849,
-        angle: "220deg",
+        angle: "230deg",
       },
       {
         latitude: 1.29316,
@@ -382,7 +382,7 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.29373,
         longitude: 103.7711,
-        angle: "220deg",
+        angle: "260deg",
       },
       {
         latitude: 1.2947863120276193,
@@ -411,7 +411,6 @@ const NUSBusServices = forwardRef((props, ref) => {
         longitude: 103.80445443936672,
         angle: "150deg",
       },
-
       {
         latitude: 1.29252,
         longitude: 1.29252,
@@ -445,22 +444,22 @@ const NUSBusServices = forwardRef((props, ref) => {
       {
         latitude: 1.30099,
         longitude: 103.77217,
-        angle: "200deg",
+        angle: "230deg",
       },
       {
         latitude: 1.30206,
         longitude: 103.76916,
-        angle: "200deg",
+        angle: "220deg",
       },
       {
         latitude: 1.29646,
         longitude: 103.77235,
-        angle: "150deg",
+        angle: "190deg",
       },
       {
         latitude: 1.29362,
         longitude: 103.77708,
-        angle: "60deg",
+        angle: "80deg",
       },
       {
         latitude: 1.29094,
@@ -749,7 +748,7 @@ const NUSBusServices = forwardRef((props, ref) => {
                 }}
                 anchor={{ x: 0.5, y: 0.5 }}
               >
-                <FontAwesome name="location-arrow" size={18} color="orange" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
+                <FontAwesome name="location-arrow" size={25} color="orange" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
               </Marker>
             ))}
         </MapView>

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -714,7 +714,7 @@ const NUSBusServices = forwardRef((props, ref) => {
     <View style={{ flex: 1, backgroundColor: "white" }}>
       <View style={styles.mapContainer}>
         <MapView style={styles.map} userInterfaceStyle="light" region={routeSelected == "BTC" ? NUS_BTC : routeSelected == "L" ? BUKITTIMAHCAMPUS : NUS} rotateEnabled={false}>
-          <Polyline coordinates={routeDataShown.checkPointCoordsArray} strokeColor="#27f" strokeWidth={5} tappable={false} />
+          <Polyline coordinates={routeDataShown.checkPointCoordsArray} strokeColor="#27f" strokeWidth={4} tappable={false} />
           {routeDataShown.busStopsCoordsArray.map((busStopMarker, index) => (
             <Marker
               key={index}
@@ -748,12 +748,12 @@ const NUSBusServices = forwardRef((props, ref) => {
                 }}
                 anchor={{ x: 0.5, y: 0.5 }}
               >
-                <FontAwesome name="location-arrow" size={25} color="orange" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
+                <FontAwesome name="location-arrow" size={18} color="#27f" style={{ transform: [{ rotate: `${directionMarker.angle}` }] }} />
               </Marker>
             ))}
         </MapView>
       </View>
-      <ScrollView>
+      <ScrollView style={{marginTop: 10}}>
         {NUS_BUS_SERVICES.map((busService, index) => (
           <Pressable key={index} onPress={() => setRouteSelected(busService)}>
             <ServiceCard busService={busService} busStops={fetchDetailedStopNames(busService)} displayedStops={fetchBaseCardData(busService)} />

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -268,7 +268,7 @@ const NUSBusServices = forwardRef((props, ref) => {
   }, [routeSelected]);
 
   const NUS = {
-    latitude: 1.2959,
+    latitude: 1.2950,
     longitude: 103.7771,
     latitudeDelta: 0.015,
     longitudeDelta: 0.015,

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -714,7 +714,7 @@ const NUSBusServices = forwardRef((props, ref) => {
   return (
     <View style={{ flex: 1, backgroundColor: "white" }}>
       <View style={styles.mapContainer}>
-        <MapView style={styles.map} region={routeSelected == "BTC" ? NUS_BTC : routeSelected == "L" ? BUKITTIMAHCAMPUS : NUS} rotateEnabled={false}>
+        <MapView style={styles.map} userInterfaceStyle="light" region={routeSelected == "BTC" ? NUS_BTC : routeSelected == "L" ? BUKITTIMAHCAMPUS : NUS} rotateEnabled={false}>
           <Polyline coordinates={routeDataShown.checkPointCoordsArray} strokeColor="#27f" strokeWidth={5} tappable={false} />
           {routeDataShown.busStopsCoordsArray.map((busStopMarker, index) => (
             <Marker

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -7,7 +7,7 @@ import MapView, {
   Polyline,
 } from "react-native-maps";
 import axios from "axios";
-import { ServiceCard } from "@/components/busServicesLive/busServiceCard";
+import ServiceCard from "@/components/busServicesLive/busServiceCard";
 import CustomMarker from "@/components/busServicesLive/busStopMarker";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import ActiveBusMarker from "@/components/busServicesLive/activeBusMarker";
@@ -754,10 +754,15 @@ const NUSBusServices = forwardRef((props, ref) => {
         </MapView>
       </View>
       <ScrollView style={{marginTop: 10}}>
-        {NUS_BUS_SERVICES.map((busService, index) => (
-          <Pressable key={index} onPress={() => setRouteSelected(busService)}>
-            <ServiceCard busService={busService} busStops={fetchDetailedStopNames(busService)} displayedStops={fetchBaseCardData(busService)} />
-          </Pressable>
+      {NUS_BUS_SERVICES.map((busService, index) => (
+          <ServiceCard
+            key={index}
+            busService={busService}
+            busStops={fetchDetailedStopNames(busService)}
+            displayedStops={fetchBaseCardData(busService)}
+            onPress={() => setRouteSelected(busService)}
+            selected={routeSelected === busService}
+          />
         ))}
       </ScrollView>
     </View>

--- a/frontend/app/(tabs)/busservices.tsx
+++ b/frontend/app/(tabs)/busservices.tsx
@@ -268,10 +268,10 @@ const NUSBusServices = forwardRef((props, ref) => {
   }, [routeSelected]);
 
   const NUS = {
-    latitude: 1.2966,
-    longitude: 103.7764,
-    latitudeDelta: 0.02,
-    longitudeDelta: 0.02,
+    latitude: 1.2959,
+    longitude: 103.7771,
+    latitudeDelta: 0.015,
+    longitudeDelta: 0.015,
   };
   const NUS_BTC = {
     latitude: 1.301243123663655,

--- a/frontend/app/(tabs)/routefindingScreens/DetailedRouteScreen.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/DetailedRouteScreen.tsx
@@ -352,6 +352,7 @@ const DetailedRouteScreen: React.FC = () => {
     <View style={stylesheet.SafeAreaView} testID="test">
       <MapView
         style={stylesheet.MapView}
+        userInterfaceStyle="light"
         initialRegion={{
           latitude: (origin.latitude + destination.latitude) / 2,
           longitude: (origin.longitude + destination.longitude) / 2,

--- a/frontend/app/(tabs)/routefindingScreens/Main.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/Main.tsx
@@ -21,7 +21,7 @@ const App = forwardRef((props, ref) => {
   //hooks
   const router = useRouter();
   const scaleAnim = useRef(new Animated.Value(1)).current;
-  const mapRef = useRef<MapView>(null); 
+  const mapRef = useRef<MapView>(null);
   const [currentLocation, setCurrentLocation] = useState<Location.LocationObjectCoords>({
     latitude: 1.3521,
     longitude: 103.8198,
@@ -116,12 +116,14 @@ const App = forwardRef((props, ref) => {
 
   const handlePressOut = () => {
     getLocation();
-    mapRef.current!.animateToRegion({
-      latitude: currentLocation.latitude,
-      longitude: currentLocation.longitude,
-      latitudeDelta: 0.005,
-      longitudeDelta: 0.005,
-    });
+    if (mapRef.current) {
+      mapRef.current!.animateToRegion({
+        latitude: currentLocation.latitude,
+        longitude: currentLocation.longitude,
+        latitudeDelta: 0.005,
+        longitudeDelta: 0.005,
+      });
+    }
     Animated.spring(scaleAnim, {
       toValue: 1,
       speed: 25,
@@ -286,7 +288,7 @@ const App = forwardRef((props, ref) => {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <View style={styles.container}>
-        <MapView ref={mapRef} style={styles.map} region={region} testID="current-location-map" userInterfaceStyle="light" >
+        <MapView ref={mapRef} style={styles.map} region={region} testID="current-location-map" userInterfaceStyle="light">
           {currentLocation && (
             <Marker
               testID="current-location-marker"

--- a/frontend/app/(tabs)/routefindingScreens/Main.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/Main.tsx
@@ -111,7 +111,6 @@ const App = forwardRef((props, ref) => {
   };
 
   useEffect(() => {
-    //to query for location permission
     getLocation(); //initial call
 
     const intervalId = setInterval(() => {

--- a/frontend/app/(tabs)/routefindingScreens/Main.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/Main.tsx
@@ -21,6 +21,7 @@ const App = forwardRef((props, ref) => {
   //hooks
   const router = useRouter();
   const scaleAnim = useRef(new Animated.Value(1)).current;
+  const mapRef = useRef<MapView>(null); 
   const [currentLocation, setCurrentLocation] = useState<Location.LocationObjectCoords>({
     latitude: 1.3521,
     longitude: 103.8198,
@@ -75,8 +76,8 @@ const App = forwardRef((props, ref) => {
   const getLocation = async () => {
     try {
       let location;
-      // Because getCurrentPositionAsync() is awfully slow in IOS (~9seconds), expo-location documentation
-      // recommends using getLastKnownPositionAsync() instead. 
+      // Because getCurrentPositionAsync() is awfully slow in IOS (~9seconds),
+      // expo-location documentation recommends using getLastKnownPositionAsync() instead.
       if (Platform.OS === "ios") {
         const last = await Location.getLastKnownPositionAsync();
         if (last) {
@@ -115,6 +116,13 @@ const App = forwardRef((props, ref) => {
 
   const handlePressOut = () => {
     getLocation();
+    mapRef.current!.animateToRegion({
+      latitude: currentLocation.latitude,
+      longitude: currentLocation.longitude,
+      latitudeDelta: 0.005,
+      longitudeDelta: 0.005,
+    });
+    console.log(region)
     Animated.spring(scaleAnim, {
       toValue: 1,
       speed: 25,
@@ -280,7 +288,7 @@ const App = forwardRef((props, ref) => {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <View style={styles.container}>
-        <MapView style={styles.map} region={region} testID="current-location-map" userInterfaceStyle="light">
+        <MapView ref={mapRef} style={styles.map} region={region} testID="current-location-map" userInterfaceStyle="light" >
           {currentLocation && (
             <Marker
               testID="current-location-marker"

--- a/frontend/app/(tabs)/routefindingScreens/Main.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/Main.tsx
@@ -122,7 +122,6 @@ const App = forwardRef((props, ref) => {
       latitudeDelta: 0.005,
       longitudeDelta: 0.005,
     });
-    console.log(region)
     Animated.spring(scaleAnim, {
       toValue: 1,
       speed: 25,
@@ -231,7 +230,6 @@ const App = forwardRef((props, ref) => {
 
   async function fetchRoutesFromServer(origin: LatLng, destination: LatLng): Promise<baseResultsCardType[]> {
     if (oneMapsAPIToken) {
-      console.log(oneMapsAPIToken);
       try {
         const response = await axios.post(
           "https://nusmaps.onrender.com/transportRoute",

--- a/frontend/app/(tabs)/routefindingScreens/ResultsScreen.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/ResultsScreen.tsx
@@ -135,6 +135,7 @@ const RefactoredResultsScreen: React.FC = () => {
           <View style={{ width: "100%", height: "50%" }}>
             <MapView
               style={{ width: "100%", height: "100%" }}
+              userInterfaceStyle="light"
               initialRegion={{
                 latitude: (parsedOrigin.latitude + parsedDestination.latitude) / 2,
                 longitude: (parsedOrigin.longitude + parsedDestination.longitude) / 2,

--- a/frontend/app/(tabs)/routefindingScreens/__tests__/main.test.tsx
+++ b/frontend/app/(tabs)/routefindingScreens/__tests__/main.test.tsx
@@ -10,6 +10,11 @@ import { GooglePlaceData } from "react-native-google-places-autocomplete";
 
 jest.useFakeTimers();
 
+jest.mock('react-native/Libraries/Utilities/Platform', () => ({
+  OS: 'android', // or 'ios'
+  select: () => null
+}));
+
 jest.mock("expo-location", () => ({
   requestForegroundPermissionsAsync: jest.fn(),
   getCurrentPositionAsync: jest.fn(),

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -7,7 +7,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import axios from "axios";
 import * as SplashScreen from "expo-splash-screen";
 import * as Location from "expo-location";
-import { StatusBar } from 'expo-status-bar';
+import { StatusBar } from "react-native";
+import { Text, View } from "react-native";
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -91,9 +92,16 @@ export default function RootLayout() {
     }
   }, [permissionErrorMsg]);
 
+  // Setting the status bar to dark colour requires a delay due to a known bug (see: https://github.com/expo/expo/issues/2813)
+  const delay = (fun: any, timeout: number) => new Promise((resolve) => setTimeout(resolve, timeout)).then(fun);
+  const closePreview = () => {
+    delay(() => StatusBar.setBarStyle("dark-content"), 3);
+  };
+  closePreview();
+
   return (
     <>
-      <StatusBar backgroundColor="white" style="dark" />
+      <StatusBar />
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -20,12 +20,6 @@ export default function RootLayout() {
     "Inter-SemiBold": require("../assets/fonts/Inter-SemiBold.otf"),
   });
 
-  // Forces dark status bar text (ignores device light/dark mode).
-  useEffect(() => {
-    StatusBar.setBackgroundColor("white");
-    StatusBar.setBarStyle("dark-content");
-  }, []);
-
   useEffect(() => {
     if (fontsLoaded || error) {
       SplashScreen.hideAsync();
@@ -99,6 +93,7 @@ export default function RootLayout() {
 
   return (
     <>
+      <StatusBar backgroundColor="white" barStyle="dark-content" />
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from "react";
 import "react-native-reanimated";
 import Toast from "react-native-toast-message";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { StatusBar } from "react-native";
 import axios from "axios";
 import * as SplashScreen from "expo-splash-screen";
 import * as Location from "expo-location";
+import { StatusBar } from 'expo-status-bar';
 
 // Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
@@ -93,7 +93,7 @@ export default function RootLayout() {
 
   return (
     <>
-      <StatusBar backgroundColor="white" barStyle="dark-content" />
+      <StatusBar backgroundColor="white" style="dark" />
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" />

--- a/frontend/components/busServicesLive/busServiceCard.tsx
+++ b/frontend/components/busServicesLive/busServiceCard.tsx
@@ -17,10 +17,21 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, display
   let stops = displayedStops.flatMap((stop: string) => [stop, "rightArrow"]);
   stops.pop(); //removes the last arrow
   return (
-    <Pressable 
-      onPressIn={() => setIsPressed(true)} 
-      onPressOut={() => setIsPressed(false)} 
-      onPress={onPress} style={({ pressed }) => [styles.cardContainer, { backgroundColor: pressed || isPressed ? "#e0e0e0" : selected ? "#c0c0c0" : "#fff" }]}
+    <Pressable
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.cardContainer,
+        {
+          backgroundColor: pressed || isPressed ? "#ced9e5" : selected ? "#e5f2ff" : "#fff",
+          borderColor: selected ? "#007bff" : "#ccc",
+          borderWidth: selected ? 2 : 0.5,
+          padding: selected ? 0: 1.5,
+          shadowOffset: { width: 0, height: pressed || isPressed || selected ? 1 : 3 },
+          shadowOpacity: pressed || isPressed || selected ? 0.1 : 0.2,
+        },
+      ]}
     >
       <View style={styles.cardContentContainer}>
         <ColouredCircle color={mapBusServiceColour(busService)} size={15} />

--- a/frontend/components/busServicesLive/busServiceCard.tsx
+++ b/frontend/components/busServicesLive/busServiceCard.tsx
@@ -26,7 +26,6 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, display
         {
           backgroundColor: pressed || isPressed ? "#ced9e5" : selected ? "#e5f2ff" : "#fff",
           borderColor: selected ? "#007bff" : "#ccc",
-          borderWidth: selected ? 0.5 : 0.5,
           shadowOffset: { width: 0, height: pressed || isPressed ? 1 : selected ? 2 : 3 },
           shadowOpacity: pressed || isPressed ? 0.1 : selected ? 0.1 : 0.2,
         },

--- a/frontend/components/busServicesLive/busServiceCard.tsx
+++ b/frontend/components/busServicesLive/busServiceCard.tsx
@@ -26,10 +26,9 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, display
         {
           backgroundColor: pressed || isPressed ? "#ced9e5" : selected ? "#e5f2ff" : "#fff",
           borderColor: selected ? "#007bff" : "#ccc",
-          borderWidth: selected ? 2 : 0.5,
-          padding: selected ? 0: 1.5,
-          shadowOffset: { width: 0, height: pressed || isPressed || selected ? 1 : 3 },
-          shadowOpacity: pressed || isPressed || selected ? 0.1 : 0.2,
+          borderWidth: selected ? 0.5 : 0.5,
+          shadowOffset: { width: 0, height: pressed || isPressed ? 1 : selected ? 2 : 3 },
+          shadowOpacity: pressed || isPressed ? 0.1 : selected ? 0.1 : 0.2,
         },
       ]}
     >

--- a/frontend/components/busServicesLive/busServiceCard.tsx
+++ b/frontend/components/busServicesLive/busServiceCard.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { View, Text, StyleSheet } from "react-native";
+import React, { useState } from "react";
+import { View, Text, StyleSheet, Pressable } from "react-native";
 import MaterialCommunityIcons from "@expo/vector-icons/MaterialCommunityIcons";
 import ColouredCircle from "@/components/ColouredCircle";
 import mapBusServiceColour from "@/utils/mapBusServiceColor";
@@ -8,13 +8,20 @@ interface ServiceCardProps {
   busService: string;
   busStops: string[]; // the stops shown in the detailed screen
   displayedStops: string[]; // the stops that are shown in the card
+  onPress: () => void; // Function to handle press events
+  selected: boolean; // Indicate if this card is selected
 }
 
-export const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, displayedStops }) => {
+const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, displayedStops, onPress, selected }) => {
+  const [isPressed, setIsPressed] = useState(false);
   let stops = displayedStops.flatMap((stop: string) => [stop, "rightArrow"]);
   stops.pop(); //removes the last arrow
   return (
-    <View style={styles.cardContainer}>
+    <Pressable 
+      onPressIn={() => setIsPressed(true)} 
+      onPressOut={() => setIsPressed(false)} 
+      onPress={onPress} style={({ pressed }) => [styles.cardContainer, { backgroundColor: pressed || isPressed ? "#e0e0e0" : selected ? "#c0c0c0" : "#fff" }]}
+    >
       <View style={styles.cardContentContainer}>
         <ColouredCircle color={mapBusServiceColour(busService)} size={15} />
         <View style={styles.textContainer}>
@@ -34,7 +41,7 @@ export const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, 
           </View>
         </View>
       </View>
-    </View>
+    </Pressable>
   );
 };
 

--- a/frontend/components/busServicesLive/busServiceCard.tsx
+++ b/frontend/components/busServicesLive/busServiceCard.tsx
@@ -26,8 +26,8 @@ const ServiceCard: React.FC<ServiceCardProps> = ({ busService, busStops, display
         {
           backgroundColor: pressed || isPressed ? "#ced9e5" : selected ? "#e5f2ff" : "#fff",
           borderColor: selected ? "#007bff" : "#ccc",
-          shadowOffset: { width: 0, height: pressed || isPressed ? 1 : selected ? 2 : 3 },
-          shadowOpacity: pressed || isPressed ? 0.1 : selected ? 0.1 : 0.2,
+          shadowOffset: { width: 0, height: pressed || isPressed ? 1 : selected ? 3 : 3 },
+          shadowOpacity: pressed || isPressed ? 0.1 : selected ? 0.2 : 0.2,
         },
       ]}
     >

--- a/frontend/components/busStopsTab/__tests__/BusStopSearchBar.test.tsx
+++ b/frontend/components/busStopsTab/__tests__/BusStopSearchBar.test.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import BusStopSearchBar from "@/components/busStopsTab/BusStopSearchBar"; // Adjust the path as necessary
+import { NavigationContainer } from "@react-navigation/native";
+
+// Mock the useNavigation hook
+const mockNavigate = jest.fn();
+
+jest.mock("@react-navigation/native", () => {
+  const actualNav = jest.requireActual("@react-navigation/native");
+  return {
+    ...actualNav,
+    useNavigation: () => ({
+      navigate: mockNavigate,
+    }),
+  };
+});
+jest.mock("@expo/vector-icons/MaterialIcons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return ({ name, ...props }: { name: string }) => {
+    return <Text {...props}>{name}</Text>;
+  };
+});
+
+jest.mock("@expo/vector-icons/Ionicons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return ({ name, ...props }: { name: string }) => {
+    return <Text {...props}>{name}</Text>;
+  };
+});
+jest.mock("react-native-vector-icons/Ionicons", () => {
+  const React = require("react");
+  const { Text } = require("react-native");
+  return ({ name, ...props }: { name: string }) => <Text {...props}>{name}</Text>;
+});
+
+describe("BusStopSearchBar", () => {
+  it("renders correctly", () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <BusStopSearchBar />
+      </NavigationContainer>
+    );
+
+    expect(getByText("Search")).toBeTruthy();
+  });
+
+  it("navigates to BusStopSearchScreen on press", () => {
+    const { getByText } = render(
+      <NavigationContainer>
+        <BusStopSearchBar />
+      </NavigationContainer>
+    );
+
+    const searchButton = getByText("Search");
+    fireEvent.press(searchButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith("BusStopSearchScreen", { initialQuery: "" });
+  });
+});

--- a/frontend/components/busStopsTab/__tests__/BusStopSearchScreen.test.tsx
+++ b/frontend/components/busStopsTab/__tests__/BusStopSearchScreen.test.tsx
@@ -100,7 +100,7 @@ describe("BusStopSearchScreen", () => {
     updatedBusStops = JSON.parse(storedData!);
     expect(updatedBusStops[0].isFavourited).toBe(false);
     expect(updatedBusStops[1].isFavourited).toBe(false);
-  });
+  }, 10000); // 10000ms to complete as this is a long test
 
   test("Search page renders FlatList of bus stops retrieved from AsyncStorage", async () => {
     const { getByText, getByLabelText } = render(
@@ -115,7 +115,7 @@ describe("BusStopSearchScreen", () => {
       expect(getByText("COM 3")).toBeTruthy();
       expect(getByText("Prince George's Park Foyer")).toBeTruthy();
     });
-  }, 10000); // 10000ms to complete as this is a long test
+  });
 
   test("Search bar on search page is touchable", async () => {
     const { getByText, getByPlaceholderText } = render(

--- a/frontend/components/busStopsTab/__tests__/BusStopSearchScreen.test.tsx
+++ b/frontend/components/busStopsTab/__tests__/BusStopSearchScreen.test.tsx
@@ -115,7 +115,7 @@ describe("BusStopSearchScreen", () => {
       expect(getByText("COM 3")).toBeTruthy();
       expect(getByText("Prince George's Park Foyer")).toBeTruthy();
     });
-  });
+  }, 10000); // 10000ms to complete as this is a long test
 
   test("Search bar on search page is touchable", async () => {
     const { getByText, getByPlaceholderText } = render(

--- a/frontend/hooks/useUserLocation.ts
+++ b/frontend/hooks/useUserLocation.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import * as Location from "expo-location";
 import { LocationObject } from "expo-location";
 import Toast from "react-native-toast-message";
+import { Platform } from "react-native";
 
 const useUserLocation = (refreshLocation: number) => {
   const [location, setLocation] = useState<LocationObject | null>(null);
@@ -10,7 +11,20 @@ const useUserLocation = (refreshLocation: number) => {
 
   const getLocation = async () => {
     try {
-      let location = await Location.getCurrentPositionAsync({});
+      let location;
+      // Because getCurrentPositionAsync() is awfully slow in IOS,
+      // expo-location documentation recommends using getLastKnownPositionAsync() instead. 
+      if (Platform.OS === "ios") {
+        const last = await Location.getLastKnownPositionAsync();
+        if (last) {
+          location = last;
+        } else {
+          const current = await Location.getCurrentPositionAsync();
+          location = current;
+        }
+      } else {
+        location = await Location.getCurrentPositionAsync();
+      }
       setLocation(location);
       setLocationReady(true);
     } catch (error) {


### PR DESCRIPTION
IOS Location Retrieval: Added a conditional to check for IOS platform, so that we use getLastKnownPositionAsync() instead of getCurrentPositionAsync() due to the slowness of getCurrentPositionAsync() in IOS, which is about 9 seconds for me. This is a known issue documented in expo-location's documentation (https://docs.expo.dev/versions/latest/sdk/location/). You might want to try this for Android too as it might work well too.

Status Bar: Have been unable to set status bar text colour due to a known(?) bug (see: https://github.com/expo/expo/issues/2813). Tried both Expo's and React Native's implementation with no luck. The workaround is to use a delay to set the status bar colour.